### PR TITLE
Move universal portion into a note section

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,14 +62,14 @@
                     <li><span class="text-danger">Red</span> packages have no wheel archives uploaded (yet!).</li>
                 </ul>
                 <h2>My package is red. What can I do?</h2>
-                <p>If you have a pure python package that is not using 2to3 for Python 3 support, you've got it easy. Make sure Wheel is installed</p>
+                <p>If you have a pure python package that is not using 2to3 for Python 3 support, you've got it easy. Make sure Wheel is installed&hellip;</p>
                     <pre>
 pip install wheel</pre>
-                <p>Create a file called <code>setup.cfg</code> with the following content&hellip;</p>
+                <p>&hellip;and when you'd normally run <code>python setup.py sdist upload</code>, also run <code>python setup.py bdist_wheel upload</code>. For a more in-depth explanation, see this guide on <a href="https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/">sharing your labor of love</a>.</p>
+                <p><em>Note:</em>If your project is python 2 and 3 compatible you can create a universal wheel distribution. Create a file called <code>setup.cfg</code> with the following content and upload your package.</p>
                     <pre>
 [wheel]
 universal = 1</pre>
-                <p>&hellip;and when you'd normally run <code>python setup.py sdist upload</code>, also run <code>python setup.py bdist_wheel upload</code>. For a more in-depth explanation, see this guide on <a href="https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/">sharing your labor of love</a>.</p>
                 <p><em>Note:</em> this is not the solution for packages that have C extensions or other cases where a platform/architecture independent wheel is impossible. This might mean you are using 2to3 or depend on some other package that is architecture specific. Frankly, I haven't had the time to research this yet. If you know how to do it, please <a href="https://github.com/meshy/pythonwheels/issues/">create a ticket</a> so I can replace this paragraph with something useful!</p>
                 <h2>Something's wrong with this page!</h2>
                 <p>Fantastic, a problem found is a problem fixed. Please <a href="https://github.com/meshy/pythonwheels/issues/">create a ticket</a>!</p>


### PR DESCRIPTION
The universal section causes wheel to create a python 2&3 compatible version so probably best not to promote that without explaining why you do it.

Fixes #11
