### PR TITLE
Improve documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
                 <h2>Something's wrong with this page!</h2>
                 <p>Fantastic, a problem found is a problem fixed. Please <a href="https://github.com/meshy/pythonwheels/issues/">create a ticket</a>!</p>
                 <p>You can also <a href="https://github.com/meshy/pythonwheels/pulls/">submit a pull-request</a>.</p>
+                <p><em>Note: </em>Requests for behavioural changes in the packaging tools themselves should be directed to <a href="https://mail.python.org/mailman/listinfo/distutils-sig">distutils-sig</a> and the <a href="https://github.com/pypa/packaging-problems">Python Packaging Authority</a>.</p>
                 <h2>Other resources</h2>
                 <p><a href="https://pypip.in/wheel.html">PyPI Pins</a> has a pin you can use to display your wheel compatibility: <img src="https://pypip.in/wheel/blackhole/badge.png" alt="Wheel Status"></p>
                 <h2>Thanks</h2>


### PR DESCRIPTION
Add `Advantages of wheels` and `Other Resources` sections. Split information about creating wheels into `Pure Python` and `C extensions` subsections. Add link to pull-requests on github to encourage more active participation.

I have tried to cover the suggestions made in [issue #29](/meshy/pythonwheels/issues/29#issuecomment-35823104) by @zzzeek. I have also included suggestions from #22 and #16.
