### PR TITLE
Specify windows as the compiler-less upside to wheels

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
                 <ol>
                     <li>Faster installation for pure python and native C extension packages.</li>
                     <li>Avoids arbitrary code execution for installation. (Avoids setup.py)</li>
-                    <li>Installation of a C extension does not require a compiler on windows.</li>
+                    <li>Installation of a C extension does not require a compiler on Windows or OS X.</li>
                     <li>Allows better caching for testing and continuous integration.</li>
                     <li>Creates .pyc files as part of installation to ensure they match the python interpreter used.</li>
                     <li>More consistent installs across platforms and machines.</li>


### PR DESCRIPTION
This feature is currently windows specific (I believe).
