### PR TITLE
Add BeautifulSoup to deprecated

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -11,6 +11,7 @@ BASE_URL = 'https://pypi.python.org/pypi'
 DEPRECATED_PACKAGES = set((
     'distribute',
     'django-social-auth',
+    'BeautifulSoup'
 ))
 
 SESSION = requests.Session()


### PR DESCRIPTION
Hello,

https://pypi.python.org/pypi/BeautifulSoup mention:
> This package is OBSOLETE. It has been replaced by the beautifulsoup4 package. You should use Beautiful Soup 4 for all new projects.

https://pypi.python.org/pypi/beautifulsoup4 support wheels.

Greetings,