### PR TITLE
Add Python 3 support and test on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+
+# Supported CPython versions:
+# https://en.wikipedia.org/wiki/CPython#Version_history
+python:
+ - pypy3
+ - pypy
+ - 2.7
+ - 3.6
+ - 3.5
+ - 3.4
+
+sudo: false
+
+install:
+ - pip install pep8 pyflakes
+
+script:
+ # Static analysis
+ - pyflakes .
+ - pep8 --statistics --count .
+
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ sudo: false
 
 install:
  - pip install pep8 pyflakes
+ - pip install -r requirements.txt
 
 script:
  # Static analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,18 @@ language: python
 
 # Supported CPython versions:
 # https://en.wikipedia.org/wiki/CPython#Version_history
-python:
- - 2.7
- - 3.6
+python: 3.6
 
 sudo: false
 
 install:
- - pip install pep8 pyflakes
+ - pip install flake8
  - pip install -r requirements.txt
  - npm install svgexport -g
 
 script:
  # Static analysis
- - pyflakes .
- - pep8 --statistics --count .
+ - flake8 --statistics --count .
 
  # Test run
  - python generate.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ sudo: false
 install:
  - pip install pep8 pyflakes
  - pip install -r requirements.txt
+ - npm install svgexport -g
 
 script:
  # Static analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,8 @@ language: python
 # Supported CPython versions:
 # https://en.wikipedia.org/wiki/CPython#Version_history
 python:
- - pypy3
- - pypy
  - 2.7
  - 3.6
- - 3.5
- - 3.4
 
 sudo: false
 
@@ -19,6 +15,9 @@ script:
  # Static analysis
  - pyflakes .
  - pep8 --statistics --count .
+
+ # Test run
+ - python generate.py
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ script:
 
 matrix:
   fast_finish: true
+
+notifications:
+  email: false

--- a/svg_wheel.py
+++ b/svg_wheel.py
@@ -2,7 +2,7 @@ import math
 import os
 import xml.etree.ElementTree as et
 
-HEADERS = '''<?xml version=\"1.0\" standalone=\"no\"?>
+HEADERS = b'''<?xml version=\"1.0\" standalone=\"no\"?>
 <?xml-stylesheet href="wheel.css" type="text/css"?>
 <!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"
 \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">
@@ -118,7 +118,7 @@ def generate_svg_wheel(packages, total):
 
     add_fraction(wheel, packages, total)
 
-    with open('wheel.svg', 'w') as svg:
+    with open('wheel.svg', 'wb') as svg:
         svg.write(HEADERS)
         svg.write(et.tostring(wheel))
 

--- a/utils.py
+++ b/utils.py
@@ -63,7 +63,8 @@ def annotate_wheels(packages):
         else:
             package['css_class'] = 'default'
             package['icon'] = u'\u2717'  # Ballot X
-            package['title'] = 'This package has no wheel archives uploaded (yet!).'
+            package['title'] = ('This package has no wheel archives uploaded '
+                                '(yet!).')
 
 
 def get_top_packages():

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,9 @@
-from __future__ import print_function
 import datetime
 import json
+import xmlrpc.client
+
 import pytz
 import requests
-import xmlrpc.client
 
 
 BASE_URL = 'https://pypi.python.org/pypi'

--- a/utils.py
+++ b/utils.py
@@ -1,15 +1,9 @@
 from __future__ import print_function
 import datetime
 import json
-try:
-    # Python 2.7
-    import xmlrpclib
-except ImportError:
-    # Python 3
-    import xmlrpc.client as xmlrpclib
-
 import pytz
 import requests
+import xmlrpc.client
 
 
 BASE_URL = 'https://pypi.python.org/pypi'
@@ -24,7 +18,7 @@ SESSION = requests.Session()
 
 
 def req_rpc(method, *args):
-    payload = xmlrpclib.dumps(args, method)
+    payload = xmlrpc.client.dumps(args, method)
 
     response = SESSION.post(
         BASE_URL,
@@ -32,7 +26,7 @@ def req_rpc(method, *args):
         headers={'Content-Type': 'text/xml'},
     )
     if response.status_code == 200:
-        result = xmlrpclib.loads(response.content)[0][0]
+        result = xmlrpc.client.loads(response.content)[0][0]
         return result
     else:
         # Some error occurred

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,12 @@
+from __future__ import print_function
 import datetime
 import json
-import xmlrpclib
+try:
+    # Python 2.7
+    import xmlrpclib
+except ImportError:
+    # Python 3
+    import xmlrpc.client as xmlrpclib
 
 import pytz
 import requests
@@ -41,7 +47,7 @@ def annotate_wheels(packages):
     print('Getting wheel data...')
     num_packages = len(packages)
     for index, package in enumerate(packages):
-        print index + 1, num_packages, package['name']
+        print(index + 1, num_packages, package['name'])
         has_wheel = False
         url = get_json_url(package['name'])
         response = SESSION.get(url)
@@ -79,7 +85,7 @@ def not_deprecated(package):
 
 def remove_irrelevant_packages(packages, limit):
     print('Removing cruft...')
-    active_packages = filter(not_deprecated, packages)
+    active_packages = list(filter(not_deprecated, packages))
     return active_packages[:limit]
 
 


### PR DESCRIPTION
Please enable Travis CI for this repo at https://travis-ci.org/profile/

See .travis.yml for what it does: some static analysis and then does a test run of `python generate.py`.

Here's an example build: https://travis-ci.org/hugovk/pythonwheels/builds/283534796