### PR TITLE
Add information about including the project license in wheels

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,11 @@ pip install wheel</pre>
 [bdist_wheel]
 universal = 1</pre>
                         <p><strong>Warning: </strong>If your project has optional C extensions, it is recommended not to publish a universal wheel, because pip will prefer the wheel over a source installation.</p>
+                    <p><em>Note: </em>To include your project's license file in the wheel distribution, specify the <code>license_file</code> key in the <code>[metadata]</code> section. This helps comply with many open source licenses that require the license text to be included in every distributable artifact of the project.</p>
+                        <pre>
+[metadata]
+license_file = LICENSE
+</pre>
                     <h3 id="dirty-wheel">C extensions</h3>
                     <p>PyPI currently allows uploading platform-specific wheels for Windows, macOS and Linux. It is useful to create wheels for these platforms, as it avoids the need for your users to compile the package when installing.</p>
                     <p>You will need to have access to the platform you are building for.</p>


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the [metadata] section in the setup.cfg file. To support best practices of including licenses with distributions, add details on how
to use this. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Fixes #95