### PR TITLE
Use fresher download stats from PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 node_modules
 results.json
+top-pypi-packages.json
 wheel.png
 wheel.svg

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ install:
  - npm install svgexport -g
 
 script:
+ # Fetch fresh copy of top packages
+ - wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.min.json -O top-pypi-packages.json
+
  # Static analysis
  - flake8 --statistics --count .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,11 @@ install:
  - npm install svgexport -g
 
 script:
- # Fetch fresh copy of top packages
- - wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.min.json -O top-pypi-packages.json
-
  # Static analysis
  - flake8 --statistics --count .
 
  # Test run
- - python generate.py
+ - make generate
 
 matrix:
   fast_finish: true

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ help:
 	@echo "make update   -- upload the json and index.html to s3"
 
 generate:
+	wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.min.json -O top-pypi-packages.json
 	python generate.py
 
 update:

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
                     <li><span class="text-muted">White</span> packages have no wheel archives uploaded (yet!).</li>
                 </ul>
                 <p>Packages that are known to be deprecated are not included. (For example distribute). If your package is incorrectly listed, please <a href="https://github.com/meshy/pythonwheels/issues/">create a ticket</a>.</p>
+                <p>This used to show the all-time most-downloaded packages. The all-time list is no longer available, and the packages in <a href="https://hugovk.github.io/top-pypi-packages/">the last-365-days list</a> will change to reflect more closely what the Python community is using.
                 <p>This is not the official website for wheels, just a nice visual way to measure adoption. To see the authoritative guide on wheels and other aspects of Python packaging, see the <a href="https://packaging.python.org">Python Packaging User Guide</a>.</p>
                 <h2 id="creating-wheels">My package is white. What can I do?</h2>
                     <h3 id="pure-wheel">Pure Python</h3>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pytz==2017.2
-requests==2.18.4
+pytz==2018.5
+requests==2.19.1

--- a/utils.py
+++ b/utils.py
@@ -55,7 +55,7 @@ def get_top_packages():
     print('Getting packages...')
 
     with open('top-pypi-packages.json') as data_file:
-        packages = json.load(data_file)
+        packages = json.load(data_file)['rows']
 
     # Rename keys
     for package in packages:

--- a/utils.py
+++ b/utils.py
@@ -7,9 +7,11 @@ import requests
 BASE_URL = 'https://pypi.python.org/pypi'
 
 DEPRECATED_PACKAGES = {
+    'BeautifulSoup',
     'distribute',
     'django-social-auth',
-    'BeautifulSoup'
+    'pep8',
+    'sklearn',
 }
 
 SESSION = requests.Session()

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ import pytz
 import requests
 
 
-BASE_URL = 'https://pypi.python.org/pypi'
+BASE_URL = 'https://pypi.org/pypi'
 
 DEPRECATED_PACKAGES = {
     'BeautifulSoup',

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,5 @@
 import datetime
 import json
-import xmlrpc.client
-
 import pytz
 import requests
 
@@ -15,22 +13,6 @@ DEPRECATED_PACKAGES = set((
 ))
 
 SESSION = requests.Session()
-
-
-def req_rpc(method, *args):
-    payload = xmlrpc.client.dumps(args, method)
-
-    response = SESSION.post(
-        BASE_URL,
-        data=payload,
-        headers={'Content-Type': 'text/xml'},
-    )
-    if response.status_code == 200:
-        result = xmlrpc.client.loads(response.content)[0][0]
-        return result
-    else:
-        # Some error occurred
-        pass
 
 
 def get_json_url(package_name):
@@ -69,8 +51,16 @@ def annotate_wheels(packages):
 
 def get_top_packages():
     print('Getting packages...')
-    packages = req_rpc('top_packages')
-    return [{'name': n, 'downloads': d} for n, d in packages]
+
+    with open('top-pypi-packages.json') as data_file:
+        packages = json.load(data_file)
+
+    # Rename keys
+    for package in packages:
+        package['downloads'] = package.pop('download_count')
+        package['name'] = package.pop('project')
+
+    return packages
 
 
 def not_deprecated(package):

--- a/utils.py
+++ b/utils.py
@@ -6,11 +6,11 @@ import requests
 
 BASE_URL = 'https://pypi.python.org/pypi'
 
-DEPRECATED_PACKAGES = set((
+DEPRECATED_PACKAGES = {
     'distribute',
     'django-social-auth',
     'BeautifulSoup'
-))
+}
 
 SESSION = requests.Session()
 

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,9 @@ DEPRECATED_PACKAGES = {
     'BeautifulSoup',
     'distribute',
     'django-social-auth',
+    'nose',
     'pep8',
+    'pycrypto',
     'sklearn',
 }
 


### PR DESCRIPTION
Fixes #94.

I've made this, which is a weekly dump of the 5,000 most-downloaded packages from PyPI, using pypinfo.

* https://github.com/hugovk/top-pypi-packages
* https://hugovk.github.io/top-pypi-packages/

As `top_packages` is being removed from the PyPI API, here's a PR to instead use data from top-pypi-packages.

You'll need to stick a wget or curl to download the latest version of either the data before running generate.py; see .travis.yml for an example.

There's a choice of data over the preceding 30 days or 365 days. Perhaps a shorter timespan may give more "relevant" results. Here's a comparison.

## Pre-PR

<img width=50% src=https://user-images.githubusercontent.com/1324225/37867625-0e0a3680-2fa4-11e8-8e76-3eec73ad75ef.png>

## 365 days

<img width=50% src=https://user-images.githubusercontent.com/1324225/37867633-1ad6e49e-2fa4-11e8-8b37-c2418999d090.png>

## 30 days

<img width=50% src=https://user-images.githubusercontent.com/1324225/37867636-23c5386c-2fa4-11e8-9a9c-d925b5bb3333.png>
