### PR TITLE
Show percent in tooltip

### DIFF
--- a/svg_wheel.py
+++ b/svg_wheel.py
@@ -82,7 +82,7 @@ def add_fraction(wheel, packages, total):
     packages_with_wheels.text = '{0}'.format(wheel_packages)
 
     title = et.SubElement(packages_with_wheels, 'title')
-    percentage = '{:.0%}'.format(wheel_packages/float(total))
+    percentage = '{:.0%}'.format(wheel_packages/total)
     title.text = percentage
 
     # Dividing line

--- a/svg_wheel.py
+++ b/svg_wheel.py
@@ -81,6 +81,10 @@ def add_fraction(wheel, packages, total):
     )
     packages_with_wheels.text = '{0}'.format(wheel_packages)
 
+    title = et.SubElement(packages_with_wheels, 'title')
+    percentage = '{:.0%}'.format(wheel_packages/float(total))
+    title.text = percentage
+
     # Dividing line
     et.SubElement(
         wheel, 'line',
@@ -96,6 +100,9 @@ def add_fraction(wheel, packages, total):
         attrib=text_attributes,
     )
     total_packages.text = '{0}'.format(total)
+
+    title = et.SubElement(total_packages, 'title')
+    title.text = percentage
 
 
 def generate_svg_wheel(packages, total):


### PR DESCRIPTION
Show the percentage in a title/tooltip when hovering over the fraction.

<img width=50% src=https://user-images.githubusercontent.com/1324225/37868004-e0862bc4-2fa8-11e8-84e2-523e357002db.png>

It actually adds it in two places: one for the numerator, the other for the denominator.