### PR TITLE
Do not recommend `setup.py upload`

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                     <p>If you have a pure Python package that is not using 2to3 for Python 3 support, you've got it easy. Make sure Wheel is installed&hellip;</p>
                         <pre>
 pip install wheel</pre>
-                    <p>&hellip;and when you'd normally run <code>python setup.py sdist upload</code>, run instead <code>python setup.py sdist bdist_wheel upload</code>. For a more in-depth explanation, see this guide on <a href="https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/">sharing your labor of love</a>.</p>
+                    <p>&hellip;and when you'd normally run <code>python setup.py sdist</code>, run instead <code>python setup.py sdist bdist_wheel</code>. For a more in-depth explanation, see this guide on <a href="https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/">sharing your labor of love</a>.</p>
                     <p><em>Note: </em>If your project is Python 2 and 3 compatible you can create a universal wheel distribution. Create a file called <code>setup.cfg</code> with the following content and upload your package.</p>
                         <pre>
 [bdist_wheel]


### PR DESCRIPTION
`python setup.py upload` has been deprecated for a long time; the replacement is [twine](https://packaging.python.org/key_projects/#twine), which is already explained in the Python Packaging User Guide and in the blogpost linked in the following sentence.

Fixes #111.