### PR TITLE
Encourage license_files option rather than deprecated license_file

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,10 +54,10 @@ pip install wheel</pre>
 [bdist_wheel]
 universal = 1</pre>
                         <p><strong>Warning: </strong>If your project has optional C extensions, it is recommended not to publish a universal wheel, because pip will prefer the wheel over a source installation.</p>
-                    <p><em>Note: </em>To include your project's license file in the wheel distribution, specify the <code>license_file</code> key in the <code>[metadata]</code> section. This helps comply with many open source licenses that require the license text to be included in every distributable artifact of the project.</p>
+                    <p><em>Note: </em>To include your project's license file in the wheel distribution, specify the <code>license_files</code> key in the <code>[metadata]</code> section. This helps comply with many open source licenses that require the license text to be included in every distributable artifact of the project.</p>
                         <pre>
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 </pre>
                     <h3 id="dirty-wheel">C extensions</h3>
                     <p>PyPI currently allows uploading platform-specific wheels for Windows, macOS and Linux. It is useful to create wheels for these platforms, as it avoids the need for your users to compile the package when installing.</p>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ pip install wheel</pre>
 [bdist_wheel]
 universal = 1</pre>
                         <p><strong>Warning: </strong>If your project has optional C extensions, it is recommended not to publish a universal wheel, because pip will prefer the wheel over a source installation.</p>
-                    <p><em>Note: </em>To include your project's license file in the wheel distribution, specify the <code>license_files</code> key in the <code>[metadata]</code> section. This helps comply with many open source licenses that require the license text to be included in every distributable artifact of the project.</p>
+                    <p><em>Note: </em>To include your project's license file in the wheel distribution, specify the <code>license_files</code> key in the <code>[metadata]</code> section. This helps comply with many open source licenses that require the license text to be included in every distributable artifact of the project. This option requires wheel 0.32 or newer.</p>
                         <pre>
 [metadata]
 license_files = LICENSE


### PR DESCRIPTION
`license_file` is deprecated since **0.32.0 (2018-09-29)**, use `license_files` instead.