### PR TITLE
Reference multibuild and cibuildwheel as first resource to more easily build binary wheels for C extensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@ license_files = LICENSE
 </pre>
                     <h3 id="dirty-wheel">C extensions</h3>
                     <p>PyPI currently allows uploading platform-specific wheels for Windows, macOS and Linux. It is useful to create wheels for these platforms, as it avoids the need for your users to compile the package when installing.</p>
-                    <p>You will need to have access to the platform you are building for.</p>
+                    <p>You will need to have access to the platform you are building for. Projects like <a href="https://github.com/matthew-brett/multibuild">multibuild</a> or <a href="https://github.com/joerick/cibuildwheel">cibuildwheel</a> provide tooling and guidance to build binary wheels for different platforms using various continuous integration (CI) services.</p>
                 <h2 id="bugs">Something's wrong with this page!</h2>
                 <p>Fantastic, a problem found is a problem fixed. Please <a href="https://github.com/meshy/pythonwheels/issues/">create a ticket</a>!</p>
                 <p>You can also <a href="https://github.com/meshy/pythonwheels/pulls/">submit a pull-request</a>.</p>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@ license_files = LICENSE
 </pre>
                     <h3 id="dirty-wheel">C extensions</h3>
                     <p>PyPI currently allows uploading platform-specific wheels for Windows, macOS and Linux. It is useful to create wheels for these platforms, as it avoids the need for your users to compile the package when installing.</p>
-                    <p>You will need to have access to the platform you are building for. Projects like <a href="https://github.com/matthew-brett/multibuild">multibuild</a> or <a href="https://github.com/joerick/cibuildwheel">cibuildwheel</a> provide tooling and guidance to build binary wheels for different platforms using various continuous integration (CI) services.</p>
+                    <p>You will need to have access to the platform you are building for. Projects like <a href="https://github.com/pypa/cibuildwheel">cibuildwheel</a> or <a href="https://github.com/multibuild/multibuild">multibuild</a> provide tooling and guidance to build binary wheels for different platforms using various continuous integration (CI) services.</p>
                 <h2 id="bugs">Something's wrong with this page!</h2>
                 <p>Fantastic, a problem found is a problem fixed. Please <a href="https://github.com/meshy/pythonwheels/issues/">create a ticket</a>!</p>
                 <p>You can also <a href="https://github.com/meshy/pythonwheels/pulls/">submit a pull-request</a>.</p>


### PR DESCRIPTION
As some first references to guide users that want/need to build binary wheels, [multibuild](https://github.com/matthew-brett/multibuild) and [cibuildwheel](https://github.com/joerick/cibuildwheel﻿) are useful resources to get started.

Partially addresses #59

_Disclaimer: I'm one of the `cibuildwheel` maintainers, so don't blindly take my word for it and check for yourself, but I do believe these two projects deserve to be mentioned in the context of binary wheels._