### PR TITLE
Use 30-days data, 365 is no longer available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ help:
 	@echo "make update   -- upload the json and index.html to s3"
 
 generate:
-	wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.min.json -O top-pypi-packages.json
+	wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json -O top-pypi-packages.json
 	python3 generate.py
 
 update:

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
                     <li><span class="text-muted">White</span> packages have no wheel archives uploaded (yet!).</li>
                 </ul>
                 <p>Packages that are known to be deprecated are not included. (For example distribute). If your package is incorrectly listed, please <a href="https://github.com/meshy/pythonwheels/issues/">create a ticket</a>.</p>
-                <p>This used to show the all-time most-downloaded packages. The all-time list is no longer available, and the packages in <a href="https://hugovk.github.io/top-pypi-packages/">the last-365-days list</a> will change to reflect more closely what the Python community is using.
+                <p>This used to show the all-time most-downloaded packages. The all-time list is no longer available, and the packages in <a href="https://hugovk.github.io/top-pypi-packages/">the last-30-days list</a> will change to reflect more closely what the Python community is using.
                 <p>This is not the official website for wheels, just a nice visual way to measure adoption. To see the authoritative guide on wheels and other aspects of Python packaging, see the <a href="https://packaging.python.org">Python Packaging User Guide</a>.</p>
                 <h2 id="creating-wheels">My package is white. What can I do?</h2>
                     <h3 id="pure-wheel">Pure Python</h3>


### PR DESCRIPTION
The list of the packages comes from the most-downloaded packages over the past 365 days, from https://hugovk.github.io/top-pypi-packages/

Unfortunately, fetching data for 365 days was taking more quota than is available, so it's no longer available (more info: https://github.com/hugovk/top-pypi-packages/issues/19). The old 365-days file is still online but may be removed at some point.

So let's replace it with the 30-days data.

It also bumps the current list slightly from 339 to 342:

![image](https://user-images.githubusercontent.com/1324225/124144116-58841c00-da94-11eb-9b51-98439db40ed5.png)

![image](https://user-images.githubusercontent.com/1324225/124144136-5cb03980-da94-11eb-898b-317da5886ed0.png)
