### PR TITLE
Add bs4 to `DEPRECATED_PACKAGES`

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,7 @@ BASE_URL = "https://pypi.org/pypi"
 
 DEPRECATED_PACKAGES = {
     "BeautifulSoup",
+    "bs4",
     "distribute",
     "django-social-auth",
     "nose",


### PR DESCRIPTION
We're currently at 357/360:

<img width="426" alt="image" src="https://github.com/meshy/pythonwheels/assets/1324225/3bdc6d90-ab55-47e1-adea-cfb4667a0d76">

* Let's skip [bs4](https://pypi.org/project/bs4/): it's a wrapper around [beautifulsoup4](https://pypi.org/project/beautifulsoup4/), which has wheels.

That takes us to 358/360.

The remaining two:

* future: issue requesting a wheel https://github.com/PythonCharmers/python-future/issues/411
* pyspark: I didn't find an issue