### PR TITLE
Fix deploy: Skip deleted package pypular

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -13,6 +13,7 @@ DEPRECATED_PACKAGES = {
     "nose",
     "pep8",
     "pycrypto",
+    "pypular",
     "sklearn",
 }
 


### PR DESCRIPTION
The site last deployed 20 days ago:

> Last updated Thursday, 06 June 2024, 10:02:15 UTC. (Updated daily.)

This is because we're [getting an error](https://github.com/meshy/pythonwheels/actions/runs/9677620673/job/26699666594#step:5:408):

```pytb
python3 generate.py
Traceback (most recent call last):
  File "/home/runner/work/pythonwheels/pythonwheels/generate.py", line 20, in <module>
Getting packages...
Removing cruft...
Getting wheel data...
    main()
1 [36](https://github.com/meshy/pythonwheels/actions/runs/9677620673/job/26699666594#step:5:37)0 boto3
  File "/home/runner/work/pythonwheels/pythonwheels/generate.py", line 16, in main
    generate_svg_wheel(packages, TO_CHART)
  File "/home/runner/work/pythonwheels/pythonwheels/svg_wheel.py", line 1[39](https://github.com/meshy/pythonwheels/actions/runs/9677620673/job/26699666594#step:5:40), in generate_svg_wheel
    add_annular_sectors(wheel, packages, total)
  File "/home/runner/work/pythonwheels/pythonwheels/svg_wheel.py", line 59, in add_annular_sectors
    attrib={"class": result["css_class"]},
KeyError: 'css_class'
```

This is caused because the pypular package was deleted (https://pypi.org/project/pypular/) after it broke the PyPI acceptable use policy (https://tomaselli.page/blog/pypular-removed-from-pypi.html).

So let's just skip it.