### PR TITLE
Replace Distutils-SIG with discuss.python.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@ license_files = LICENSE
                 <h2 id="bugs">Something's wrong with this page!</h2>
                 <p>Fantastic, a problem found is a problem fixed. Please <a href="https://github.com/meshy/pythonwheels/issues/">create a ticket</a>!</p>
                 <p>You can also <a href="https://github.com/meshy/pythonwheels/pulls/">submit a pull-request</a>.</p>
-                <p><em>Note: </em>Requests for behavioural changes in the packaging tools themselves should be directed to <a href="https://mail.python.org/mailman/listinfo/distutils-sig">distutils-sig</a> and the <a href="https://github.com/pypa/packaging-problems">Python Packaging Authority</a>.</p>
+                <p><em>Note: </em>Requests for behavioural changes in the packaging tools themselves should be directed to <a href="https://discuss.python.org/c/packaging/14">discuss.python.org</a> and the <a href="https://github.com/pypa/packaging-problems">Python Packaging Authority</a>.</p>
                 <h2 id="thanks">Thanks</h2>
                 <p>Thanks to the <a href="https://python3wos.appspot.com/">Python 3 Wall of Superpowers</a> for the concept and making their code open source, <a href="https://twitter.com/dstufft">Donald Stufft</a> for his help on IRC, <a href="https://twitter.com/jturnbull">James Turnbull</a> for the intro copy, and <a href="https://ghickman.co.uk/">George Hickman</a> for pointing me in the right direction as usual.</p>
             <p>Thanks also to the many <a href="https://github.com/meshy/pythonwheels/graphs/contributors">contributors</a>.</p>


### PR DESCRIPTION
Distutils-SIG has been shut down:

https://mail.python.org/archives/list/distutils-sig@python.org/thread/TINMM5LQKQTTJDVGC224RMG7JGPXL4MQ/

And replaced with the Packaging category on https://discuss.python.org/c/packaging/14