### PR TITLE
Display the packages with wheels compatible with the newest Python

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,12 +70,17 @@
                 <h2 id="about-list">What is this list?</h2>
                 <p>This site shows the top 360 most-downloaded packages on <a href="https://pypi.org/">PyPI</a> showing which have been uploaded as wheel archives.</p>
                 <ul>
-                    <li><span class="text-success">Green</span> packages offer wheels,</li>
+                    <li><span class="text-success">Green</span> packages offer wheels compatible with the newest Python version (updated shortly before its final release),</li>
+                    <li><span class="text-warning">Orange</span> packages offer older wheels,</li>
                     <li><span class="text-muted">White</span> packages have no wheel archives uploaded (yet!).</li>
                 </ul>
+                <p>Currently, Python 3.13 is considered the newest Python version.</p>
                 <p>Packages that are known to be deprecated are not included. (For example distribute). If your package is incorrectly listed, please <a href="https://github.com/meshy/pythonwheels/issues/">create a ticket</a>.</p>
                 <p>This used to show the all-time most-downloaded packages. The all-time list is no longer available, and the packages in <a href="https://hugovk.github.io/top-pypi-packages/">the last-30-days list</a> will change to reflect more closely what the Python community is using.
                 <p>This is not the official website for wheels, just a nice visual way to measure adoption. To see the authoritative guide on wheels and other aspects of Python packaging, see the <a href="https://packaging.python.org">Python Packaging User Guide</a>.</p>
+                <h2 id="creating-new-version-wheels">My package is orange. What can I do?</h2>
+                    <p>If you have a package that doesn't publish the wheels for the newest Python yet, consider releasing them on PyPI. This will make it possible for Python users to start developing with a new Python version from the day of its release.</p>
+                    <p>Alternatively, you can consider porting your project to the <a href="https://docs.python.org/3/c-api/stable.html#stable-application-binary-interface">stable ABI</a>.</p>
                 <h2 id="creating-wheels">My package is white. What can I do?</h2>
                     <h3 id="pure-wheel">Pure Python</h3>
                     <p>If you have a pure Python package that is not using 2to3 for Python 3 support, you've got it easy. Make sure Wheel is installed&hellip;</p>

--- a/utils.py
+++ b/utils.py
@@ -20,6 +20,11 @@ DEPRECATED_PACKAGES = {
 
 SESSION = requests.Session()
 
+# Updated ~ when the release candidates start to appear
+# Goal: to have as many as possible wheels ready to use from the day it's released
+NEWEST_PYTHON_VER = "3.13"
+NEWEST_PYTHON_ABI_TAG = "cp313"
+
 
 def get_json_url(package_name):
     return BASE_URL + "/" + package_name + "/json"
@@ -31,6 +36,7 @@ def annotate_wheels(packages):
     for index, package in enumerate(packages):
         print(index + 1, num_packages, package["name"])
         has_wheel = False
+        has_newest_wheel = False
         url = get_json_url(package["name"])
         response = SESSION.get(url)
         if response.status_code != 200:
@@ -40,13 +46,24 @@ def annotate_wheels(packages):
         for download in data["urls"]:
             if download["packagetype"] == "bdist_wheel":
                 has_wheel = True
+                abi_tag = download["filename"].split("-")[-2]
+                # wheel can be universal or compiled for the specific Python version
+                # there can be additional letters at the end of the abi tag
+                # e.g. "cp313t" built for free-threading
+                if abi_tag in ["none", "abi3"] or abi_tag.startswith(NEWEST_PYTHON_ABI_TAG):
+                    has_newest_wheel = True
         package["wheel"] = has_wheel
+        package["newest_wheel"] = has_newest_wheel
 
         # Display logic. I know, I'm sorry.
         package["value"] = 1
-        if has_wheel:
+        if has_newest_wheel:
             package["css_class"] = "success"
             package["icon"] = "\u2713"  # Check mark
+            package["title"] = f"This package provides a wheel compatible with Python {NEWEST_PYTHON_VER}."
+        elif has_wheel:
+            package["css_class"] = "warning"
+            package["icon"] = "\u23FA"  # Circle
             package["title"] = "This package provides a wheel."
         else:
             package["css_class"] = "default"

--- a/wheel.css
+++ b/wheel.css
@@ -4,6 +4,12 @@
   fill: #5CB85C;
 }
 
+.warning {
+  stroke: #d58512;
+  stroke-width: 1;
+  fill: #ed9c28;
+}
+
 .default {
   stroke: #cccccc;
   stroke-width: 1;


### PR DESCRIPTION
Motivation:
Every year, the Fedora Python contributors open a bunch of issues to upstream projects to ask them to publish the new Python wheels early. This update will increase the visibility of the projects that need our attention and may serve as a gentle nudge for the project authors to not stay behind the rest of the ecosystem.

Note: If this is not a desired improvement of pythonwheels.com, no hard feelings! In such case, I'd host the page on my own GH pages.

The rendered page:
![image](https://github.com/user-attachments/assets/ca7f4b8c-534d-45bc-bbc3-eb7018811d25)
