### PR TITLE
Local dev: cache PyPI responses for one hour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 node_modules
+requests-cache.sqlite
 results.json
 top-pypi-packages.json
 wheel.svg

--- a/generate.py
+++ b/generate.py
@@ -9,12 +9,22 @@ from utils import (
 TO_CHART = 360
 
 
-def main():
-    packages = remove_irrelevant_packages(get_top_packages(), TO_CHART)
+def main(to_chart: int = TO_CHART) -> None:
+    packages = remove_irrelevant_packages(get_top_packages(), to_chart)
     annotate_wheels(packages)
     save_to_file(packages, "results.json")
-    generate_svg_wheel(packages, TO_CHART)
+    generate_svg_wheel(packages, to_chart)
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "-n", "--number", type=int, default=TO_CHART, help="number of packages to chart"
+    )
+    args = parser.parse_args()
+
+    main(args.number)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pre-commit==3.3.2
-pytz==2023.3.post1
-requests==2.31.0
+pre-commit==3.8.0
+pytz==2024.1
+requests==2.32.3
+requests-cache==1.2.1

--- a/svg_wheel.py
+++ b/svg_wheel.py
@@ -1,5 +1,4 @@
 import math
-import os
 import xml.etree.ElementTree as et
 
 HEADERS = b"""<?xml version=\"1.0\" standalone=\"no\"?>
@@ -22,7 +21,6 @@ PADDING = 10
 OUTER_RADIUS = 180
 INNER_RADIUS = OUTER_RADIUS / 2
 CENTER = PADDING + OUTER_RADIUS
-TAU = 2 * math.pi  # The angle, in radians, of a full circle.
 
 
 def annular_sector_path(start, stop):
@@ -60,9 +58,9 @@ def add_annular_sectors(wheel, packages, total):
 
 def angles(index, total):
     # Angle, in radians, of one wedge of the wheel.
-    angle_per_wedge = TAU / total
+    angle_per_wedge = math.tau / total
     # Used to turn the start of the wheel from east to north.
-    quarter_circle = TAU / 4
+    quarter_circle = math.tau / 4
 
     # Angle of the beginning of the wedge.
     start = (index * angle_per_wedge) - quarter_circle

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import pytz
-import requests
+import requests_cache
 
 
 BASE_URL = "https://pypi.org/pypi"
@@ -18,7 +18,8 @@ DEPRECATED_PACKAGES = {
     "sklearn",
 }
 
-SESSION = requests.Session()
+# Keep responses for one hour
+SESSION = requests_cache.CachedSession("requests-cache", expire_after=60 * 60)
 
 
 def get_json_url(package_name):
@@ -51,7 +52,7 @@ def annotate_wheels(packages):
         else:
             package["css_class"] = "default"
             package["icon"] = "\u2717"  # Ballot X
-            package["title"] = "This package has no wheel archives uploaded " "(yet!)."
+            package["title"] = "This package has no wheel archives uploaded (yet!)."
 
 
 def get_top_packages():


### PR DESCRIPTION
This helps local development. For the daily deploy, it won't matter, because the CI is a fresh environment and won't have the cache file (the 1-hour cache would have expired anyway).

It speeds up repeated runs from ~9 seconds to ~1 second.

First run:
```
make generate  1.76s user 0.70s system 27% cpu 8.865 total
```
Second run:
```
make generate  0.82s user 0.14s system 79% cpu 1.209 total
```

Delete `requests-cache.sqlite` to get a fresh batch.

---

Also add `--number` to `generate.py` for testing, in case you only want to fetch a few.

Finally, remove an unused import, and use `math.tau` directly ([added in 3.6](https://docs.python.org/3/library/math.html#math.tau)) instead of calculating `2 * math.pi`.
