### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ help:
 	@echo "make generate -- regenerate the json"
 
 generate:
-	wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json -O top-pypi-packages.json
+	wget https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json -O top-pypi-packages.json
 	python3 generate.py


### PR DESCRIPTION
To stay under quota, the file now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.