### PR TITLE
Group Dependabot updates into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,17 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   # Maintain dependencies for Python
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      pip:
+        patterns:
+          - "*"


### PR DESCRIPTION
This will help reduce the number of PRs each month by grouping some updates into a single PR.

Compare:

* https://github.com/hugovk/free-threaded-wheels/pull/25 (pre-commit + requests)
* https://github.com/meshy/pythonwheels/pull/172 (requests)
* https://github.com/meshy/pythonwheels/pull/173 (pre-commit)
